### PR TITLE
Fix player object underrun

### DIFF
--- a/Grid.pde
+++ b/Grid.pde
@@ -92,7 +92,7 @@ class Grid
   {
     IntVec c = grid_pos_from_absolute_pos(point);
     
-    if (c.x >= w || c.x < 0 || c.y >= h || c.y < 0)
+    if (point.x < pos.x || point.y < pos.y || c.x >= w || c.x < 0 || c.y >= h || c.y < 0)
       return new NullGriddle();
     
     return get(c.x,c.y);

--- a/Griddle.pde
+++ b/Griddle.pde
@@ -97,7 +97,7 @@ class Griddle
 
 class NullGriddle extends Griddle
 {
-  NullGriddle() { type = "NullGriddle"; }
+  NullGriddle() { type = "NullGriddle"; traversable = false; }
   
   boolean can_accept_ng(NonGriddle n) { return false; }
   


### PR DESCRIPTION
Happened because of rounding when making an int from a negative number smaller than negative one.

Resolves #13