### PR TITLE
Add griddle tags and descriptions

### DIFF
--- a/GameSession.pde
+++ b/GameSession.pde
@@ -83,6 +83,8 @@ class GameSession extends GridGameFlowBase
         globals.game.push(upmenu);
       }
     }
+    if (message.target.equals("info"))
+      toasts.add(new Toast(message.value, 5f));
   }
   
   String exit()

--- a/GriddleFactory.pde
+++ b/GriddleFactory.pde
@@ -72,6 +72,7 @@ class GriddleFactory
   }
   
   String get_spritename(String name) { return templates.get(name).getString("sprite"); }
+  String get_description(String name) { return templates.get(name).getString("description"); }
   
   StringList get_tags(String name)
   {

--- a/GriddleFactory.pde
+++ b/GriddleFactory.pde
@@ -73,7 +73,29 @@ class GriddleFactory
   
   String get_spritename(String name) { return templates.get(name).getString("sprite"); }
   
-  boolean get_reward(String name) { return templates.get(name).getBoolean("reward",false); }
+  StringList get_tags(String name)
+  {
+    StringList retval = new StringList();
+    
+    JSONObject jo = templates.get(name);
+    
+    if (!jo.hasKey("tags"))
+        return retval;
+      
+    Object jou = jo.get("tags");
+    
+    if (jou instanceof String)
+      retval.append(jou.toString());
+    else if (jou instanceof JSONArray)
+    {
+      JSONArray ja = (JSONArray)jou;
+      
+      for (int i = 0; i < ja.size(); ++i)
+        retval.append(ja.getString(i));
+    }
+    
+    return retval;    
+  }
   
   StringList get_upgrades(String name)
   {
@@ -103,7 +125,7 @@ class GriddleFactory
   
   HashMap<String, StringList> all_upgrades() { HashMap<String, StringList> retval = new HashMap<String, StringList>(); for (String k : templates.keySet()) retval.put(k, get_upgrades(k)); return retval; }
 
-  StringList all_reward_names() { StringList retval = new StringList(); for (String k : templates.keySet()) { if (get_reward(k)) retval.append(k); } return retval; }
+  StringList all_reward_names() { StringList retval = new StringList(); for (String k : templates.keySet()) { if (get_tags(k).hasValue("reward")) retval.append(k); } return retval; }
 }
 
 JSONObject merge_JSONObjects(JSONObject base, JSONObject over)

--- a/Player.pde
+++ b/Player.pde
@@ -97,10 +97,28 @@ class Player
           ng = gng;
         }
       }
+      else if (key == '?' || key == '/')
+      {
+        Griddle fg = get_faced_griddle(parent.grid);
+        
+        if (fg instanceof LevelEditorGriddle)
+        {
+          LevelEditorGriddle leg = (LevelEditorGriddle)fg;
+          
+          if (!leg.ngs.isEmpty())
+          {
+            JSONObject lengo = ((LevelEditorNonGriddle)leg.ng()).as_json;
+            globals.messages.post_message("info", globals.gFactory.get_description(lengo.getString("_template",lengo.getString("type",""))));
+          }
+        }
+        else if (fg instanceof MetaActionCounter)
+          globals.messages.post_message("info", globals.gFactory.get_description(((MetaActionCounter)fg).parameters.get(0)));
+        else
+          globals.messages.post_message("info", globals.gFactory.get_description(fg.template));
+      }
     }
     else if (keyPressed && key == 'x')
       get_faced_griddle(parent.grid).player_interact(this);
-    
     if (ng != null)
       ng.pos = PVector.fromAngle(rot).mult(dim.x * 0.4f).add(pos);
   }

--- a/data/Griddles.json
+++ b/data/Griddles.json
@@ -3,13 +3,13 @@
 		"type": "ConveyorBelt",
 		"sprite": "two arrow conveyor blue",
 		"upgrades": [ "GrabberBelt", "CrossConveyorBelt" ],
-		"reward": true,
+		"tags": [ "reward" ],
 	},
 	{
 		"type": "GrabberBelt",
 		"sprite": "two arrow conveyor yellow",
 		"upgrades": [ "SmartGrabberBelt", "SwitchGrabberBelt" ],
-		"reward": true,
+		"tags": [ "reward" ],
 	},
 	{
 		"type": "ResourcePool",
@@ -21,14 +21,14 @@
 		"type": "ResourcePool",
 		"sprite": "freezer",
 		"ng_type": "Cobalt Ore",
-		"reward": false,
+		"tags": [ "reward" ],
 	},
 	{
 		"_template": "IronOrePool",
 		"type": "ResourcePool",
 		"sprite": "freezer",
 		"ng_type": "Iron Ore",
-		"reward": true,
+		"tags": [ "reward" ],
 	},
 	{
 		"type": "EmptyGriddle",
@@ -51,7 +51,7 @@
 		"operations": ["smelt"],
 		"sprite": "furnace",
 		"upgrades": ["AutoSmelter", "FastSmelter", "ConveyorSmelter"],
-		"reward": true,
+		"tags": [ "reward", "basic" ],
 	},
 	{
 		"_template": "AutoSmelter",
@@ -73,7 +73,7 @@
 		"_template": "AutoFastSmelter",
 		"type": "Transformer",
 		"operations": ["smelt"],
-		"sprite": "furnace fast",
+		"sprite": "furnace motor fast",
 		"automatic": true,
 		"speed": 0.03,
 		"upgrades": ["AutoFastConveyorSmelter"]
@@ -116,7 +116,7 @@
 		"operations": ["crush"],
 		"sprite": "crusher",
 		"upgrades": ["AutoCrusher", "FastCrusher", "ConveyorCrusher"],
-		"reward": true,
+		"tags": [ "reward", "basic" ],
 	},
 	{
 		"_template": "AutoCrusher",
@@ -138,7 +138,7 @@
 		"_template": "AutoFastCrusher",
 		"type": "Transformer",
 		"operations": ["crush"],
-		"sprite": "crusher fast",
+		"sprite": "crusher motor fast",
 		"automatic": true,
 		"speed": 0.03,
 		"upgrades": ["AutoFastConveyorCrusher"]
@@ -181,7 +181,7 @@
 		"operations": ["extract"],
 		"sprite": "centrifuge",
 		"upgrades": ["AutoRefiner", "FastRefiner", "ConveyorRefiner"],
-		"reward": true,
+		"tags": [ "reward", "basic" ],
 	},
 	{
 		"_template": "AutoRefiner",
@@ -203,7 +203,7 @@
 		"_template": "AutoFastRefiner",
 		"type": "Transformer",
 		"operations": ["extract"],
-		"sprite": "centrifuge fast",
+		"sprite": "centrifuge motor fast",
 		"automatic": true,
 		"speed": 0.03,
 		"upgrades": ["AutoFastConveyorRefiner"]
@@ -246,7 +246,7 @@
 		"operations": ["sieve"],
 		"sprite": "trashcan gold",
 		"upgrades": ["AutoGoldSieve", "FastGoldSieve", "ConveyorGoldSieve"],
-		"reward": true,
+		"tags": [ "reward" ],
 	},
 	{
 		"_template": "AutoGoldSieve",
@@ -339,6 +339,7 @@
 		"type": "CountingOutputResourcePool",
 		"ng_type": "Gold Ingot",
 		"sprite": "freezer",
+		"tags": [ "output" ],
 	},
 	{
 		"_template": "GoldIngotOutput",
@@ -355,7 +356,7 @@
 		"type": "TrashCompactor",
 		"sprite": "trashcan",
 		"upgrades": [ "AutoTrashCompactor", "FastTrashCompactor", "GoldSieve" ],
-		"reward": true,
+		"tags": [ "reward" ],
 	},
 	{
 		"_template": "AutoTrashCompactor",

--- a/data/Griddles.json
+++ b/data/Griddles.json
@@ -1,23 +1,27 @@
 [
 	{
 		"type": "ConveyorBelt",
+		"description": "Moves things from here to there.",
 		"sprite": "two arrow conveyor blue",
 		"upgrades": [ "GrabberBelt", "CrossConveyorBelt" ],
 		"tags": [ "reward" ],
 	},
 	{
 		"type": "GrabberBelt",
+		"description": "Picks things up and moves them over here.",
 		"sprite": "two arrow conveyor yellow",
 		"upgrades": [ "SmartGrabberBelt", "SwitchGrabberBelt" ],
 		"tags": [ "reward" ],
 	},
 	{
 		"type": "ResourcePool",
+		"description": "Your own secret stash of goods.",
 		"sprite": "freezer",
 		"ng_type": "Cobalt Ore",
 	},
 	{
 		"_template": "CobaltOrePool",
+		"description": "Your own secret stash of cobalt ore.",
 		"type": "ResourcePool",
 		"sprite": "freezer",
 		"ng_type": "Cobalt Ore",
@@ -25,6 +29,7 @@
 	},
 	{
 		"_template": "IronOrePool",
+		"description": "Your own secret stash of iron ore.",
 		"type": "ResourcePool",
 		"sprite": "freezer",
 		"ng_type": "Iron Ore",
@@ -32,21 +37,25 @@
 	},
 	{
 		"type": "EmptyGriddle",
+		"description": "Nothing to see here.",
 		"sprite": "null",
 	},
 	{
 		"type": "SmartGrabberBelt",
+		"description": "Picks up one specific thing and moves it over there.",
 		"keyed_ng_type": "",
 		"sprite": "three arrow conveyor yellow",
 	},
 	{
 		"type": "Transformer",
+		"description": "Turns this into that.",
 		"operations": [ ],
 		"sprite": "crusher",
 	},
 	
 	{
 		"_template": "Smelter",
+		"description": "Turns refined goods into ingots.",
 		"type": "Transformer",
 		"operations": ["smelt"],
 		"sprite": "furnace",
@@ -55,6 +64,7 @@
 	},
 	{
 		"_template": "AutoSmelter",
+		"description": "Turns refined goods into ingots, but hands-free!",
 		"type": "Transformer",
 		"operations": ["smelt"],
 		"sprite": "furnace motor",
@@ -63,6 +73,7 @@
 	},
 	{
 		"_template": "FastSmelter",
+		"description": "Turns refined goods into ingots, but faster.",
 		"type": "Transformer",
 		"operations": ["smelt"],
 		"sprite": "furnace fast",
@@ -71,6 +82,7 @@
 	},
 	{
 		"_template": "AutoFastSmelter",
+		"description": "Turns refined goods into ingots, but hands-free and faster!",
 		"type": "Transformer",
 		"operations": ["smelt"],
 		"sprite": "furnace motor fast",
@@ -80,6 +92,7 @@
 	},
 	{
 		"_template": "ConveyorSmelter",
+		"description": "Turns refined goods into ingots, then pushes the ingots out.",
 		"type": "ConveyorTransformer",
 		"operations": ["smelt"],
 		"sprite": "furnace conveyor",
@@ -87,6 +100,7 @@
 	},
 	{
 		"_template": "AutoConveyorSmelter",
+		"description": "Turns refined goods into ingots, but hands-free. Then it pushes the ingots out.",
 		"type": "ConveyorTransformer",
 		"operations": ["smelt"],
 		"sprite": "furnace motor conveyor",
@@ -95,6 +109,7 @@
 	},
 	{
 		"_template": "FastConveyorSmelter",
+		"description": "Turns refined goods into ingots, but faster. Then it pushes the ingots out.",
 		"type": "ConveyorTransformer",
 		"operations": ["smelt"],
 		"sprite": "furnace fast conveyor",
@@ -103,6 +118,7 @@
 	},
 	{
 		"_template": "AutoFastConveyorSmelter",
+		"description": "Turns refined goods into ingots, but hands-free and faster. Then it pushes the ingots out.",
 		"type": "ConveyorTransformer",
 		"operations": ["smelt"],
 		"sprite": "furnace motor fast conveyor",
@@ -112,6 +128,7 @@
 	
 	{
 		"_template": "Crusher",
+		"description": "Turns ore into powder.",
 		"type": "Transformer",
 		"operations": ["crush"],
 		"sprite": "crusher",
@@ -120,6 +137,7 @@
 	},
 	{
 		"_template": "AutoCrusher",
+		"description": "Turns ore into powder, but hands-free!.",
 		"type": "Transformer",
 		"operations": ["crush"],
 		"sprite": "crusher motor",
@@ -128,6 +146,7 @@
 	},
 	{
 		"_template": "FastCrusher",
+		"description": "Turns ore into powder, but faster!",
 		"type": "Transformer",
 		"operations": ["crush"],
 		"sprite": "crusher fast",
@@ -136,6 +155,7 @@
 	},
 	{
 		"_template": "AutoFastCrusher",
+		"description": "Turns ore into powder, but hands-free and faster!",
 		"type": "Transformer",
 		"operations": ["crush"],
 		"sprite": "crusher motor fast",
@@ -145,6 +165,7 @@
 	},
 	{
 		"_template": "ConveyorCrusher",
+		"description": "Turns ore into powder. Then it pushes out the results.",
 		"type": "ConveyorTransformer",
 		"operations": ["crush"],
 		"sprite": "crusher conveyor",
@@ -152,6 +173,7 @@
 	},
 	{
 		"_template": "AutoConveyorCrusher",
+		"description": "Turns ore into powder, but hands-free! Then it pushes out the results.",
 		"type": "ConveyorTransformer",
 		"operations": ["crush"],
 		"sprite": "crusher motor conveyor",
@@ -160,6 +182,7 @@
 	},
 	{
 		"_template": "FastConveyorCrusher",
+		"description": "Turns ore into powder, but faster! Then it pushes out the results.",
 		"type": "ConveyorTransformer",
 		"operations": ["crush"],
 		"sprite": "crusher fast conveyor",
@@ -168,6 +191,7 @@
 	},
 	{
 		"_template": "AutoFastConveyorCrusher",
+		"description": "Turns ore into powder, but hands-free and faster! Then it pushes out the results.",
 		"type": "ConveyorTransformer",
 		"operations": ["crush"],
 		"sprite": "crusher motor fast conveyor",
@@ -177,6 +201,7 @@
 	
 	{
 		"_template": "Refiner",
+		"description": "Turns powder into refined goods.",
 		"type": "Transformer",
 		"operations": ["extract"],
 		"sprite": "centrifuge",
@@ -185,6 +210,7 @@
 	},
 	{
 		"_template": "AutoRefiner",
+		"description": "Turns powder into refined goods, but hands-free!",
 		"type": "Transformer",
 		"operations": ["extract"],
 		"sprite": "centrifuge motor",
@@ -193,6 +219,7 @@
 	},
 	{
 		"_template": "FastRefiner",
+		"description": "Turns powder into refined goods, but faster!",
 		"type": "Transformer",
 		"operations": ["extract"],
 		"sprite": "centrifuge fast",
@@ -201,6 +228,7 @@
 	},
 	{
 		"_template": "AutoFastRefiner",
+		"description": "Turns powder into refined goods, but hands-free and faster!",
 		"type": "Transformer",
 		"operations": ["extract"],
 		"sprite": "centrifuge motor fast",
@@ -210,6 +238,7 @@
 	},
 	{
 		"_template": "ConveyorRefiner",
+		"description": "Turns powder into refined goods. Then it pushes out the results.",
 		"type": "ConveyorTransformer",
 		"operations": ["extract"],
 		"sprite": "centrifuge conveyor",
@@ -217,6 +246,7 @@
 	},
 	{
 		"_template": "AutoConveyorRefiner",
+		"description": "Turns powder into refined goods, but hands-free! Then it pushes out the results.",
 		"type": "ConveyorTransformer",
 		"operations": ["extract"],
 		"sprite": "centrifuge motor conveyor",
@@ -225,6 +255,7 @@
 	},
 	{
 		"_template": "FastConveyorRefiner",
+		"description": "Turns powder into refined goods, but faster! Then it pushes out the results.",
 		"type": "ConveyorTransformer",
 		"operations": ["extract"],
 		"sprite": "centrifuge fast conveyor",
@@ -233,6 +264,7 @@
 	},
 	{
 		"_template": "AutoFastConveyorRefiner",
+		"description": "Turns powder into refined goods, but hands-free and faster! Then it pushes out the results.",
 		"type": "ConveyorTransformer",
 		"operations": ["extract"],
 		"sprite": "centrifuge motor fast conveyor",
@@ -242,6 +274,7 @@
 	
 	{
 		"_template": "GoldSieve",
+		"description": "Turns two tailings into a gold speck.",
 		"type": "Transformer",
 		"operations": ["sieve"],
 		"sprite": "trashcan gold",
@@ -250,6 +283,7 @@
 	},
 	{
 		"_template": "AutoGoldSieve",
+		"description": "Turns two tailings into a gold speck, but hands-free!",
 		"type": "Transformer",
 		"operations": ["sieve"],
 		"sprite": "trashcan gold motor",
@@ -258,6 +292,7 @@
 	},
 	{
 		"_template": "FastGoldSieve",
+		"description": "Turns two tailings into a gold speck, but faster!",
 		"type": "Transformer",
 		"operations": ["sieve"],
 		"sprite": "trashcan gold fast",
@@ -266,6 +301,7 @@
 	},
 	{
 		"_template": "AutoFastGoldSieve",
+		"description": "Turns two tailings into a gold speck, but hands-free and faster!",
 		"type": "Transformer",
 		"operations": ["sieve"],
 		"sprite": "trashcan gold fast",
@@ -275,6 +311,7 @@
 	},
 	{
 		"_template": "ConveyorGoldSieve",
+		"description": "Turns two tailings into a gold speck. Then it pushes out the results.",
 		"type": "ConveyorTransformer",
 		"operations": ["sieve"],
 		"sprite": "trashcan gold conveyor",
@@ -282,6 +319,7 @@
 	},
 	{
 		"_template": "AutoConveyorGoldSieve",
+		"description": "Turns two tailings into a gold speck, but hands-free! Then it pushes out the results.",
 		"type": "ConveyorTransformer",
 		"operations": ["sieve"],
 		"sprite": "trashcan gold motor conveyor",
@@ -290,6 +328,7 @@
 	},
 	{
 		"_template": "FastConveyorGoldSieve",
+		"description": "Turns two tailings into a gold speck, but faster! Then it pushes out the results.",
 		"type": "ConveyorTransformer",
 		"operations": ["sieve"],
 		"sprite": "trashcan gold fast conveyor",
@@ -298,6 +337,7 @@
 	},
 	{
 		"_template": "AutoFastConveyorGoldSieve",
+		"description": "Turns two tailings into a gold speck, but hands-free and faster! Then it pushes out the results.",
 		"type": "ConveyorTransformer",
 		"operations": ["sieve"],
 		"sprite": "trashcan gold motor fast conveyor",
@@ -308,27 +348,32 @@
 	
 	{
 		"_template": "Counter",
+		"description": "A plain ol' counter, but it sure can do a lot.",
 		"type": "Transformer",
 		"sprite": "counter",
-		"operations" : ["crush","smelt"],
+		"operations" : ["crush","refine","smelt"],
 		"automatic": false,
 	},
 	{
 		"type": "Player",
+		"description": "Placeholder for the player when saving the game. You should never be reading this.",
 		"sprite": "player green",
 	},
 	{
 		"type": "SwitchGrabberBelt",
+		"description": "Moves things from here to there, but you can turn it off and on.",
 		"sprite": "two arrow conveyor yellow",
 		"enabled": false,
 		"disabled_sprite": "two arrow conveyor red",
 	},
 	{
 		"type": "CrossConveyorBelt",
+		"description": "Moves things from over there to over here and from up there to down there without mixing them up!",
 		"sprite": "cross conveyor blue",
 	},
 	{
 		"type": "MetaActionCounter",
+		"description": "Use this for menus and such.",
 		"sprite": "counter",
 		"display": "Nothing here",
 		"action": "null",
@@ -336,6 +381,7 @@
 	},
 	{
 		"_template": "Output",
+		"description": "Put the goods in here and nobody has to lose...",
 		"type": "CountingOutputResourcePool",
 		"ng_type": "Gold Ingot",
 		"sprite": "freezer",
@@ -343,23 +389,27 @@
 	},
 	{
 		"_template": "GoldIngotOutput",
+		"description": "Store your gold here between rounds.",
 		"type": "CountingOutputResourcePool",
 		"ng_type": "Gold Ingot",
 		"sprite": "freezer",
 	},
 	{
 		"type": "RandomResourcePool",
+		"description": "Life's like a box of rocks. You never know what you're gonna get.",
 		"sprite": "freezer",
 		"resources": [ "Iron Ore", "Cobalt Ore" ],
 	},
 	{
 		"type": "TrashCompactor",
+		"description": "Turn two of anything into nothing!",
 		"sprite": "trashcan",
 		"upgrades": [ "AutoTrashCompactor", "FastTrashCompactor", "GoldSieve" ],
 		"tags": [ "reward" ],
 	},
 	{
 		"_template": "AutoTrashCompactor",
+		"description": "Turn two of anything into nothing! Now hands-free!",
 		"type": "TrashCompactor",
 		"sprite": "trashcan motor",
 		"upgrades": "AutoFastTrashCompactor",
@@ -367,6 +417,7 @@
 	},
 	{
 		"_template": "FastTrashCompactor",
+		"description": "Turn two of anything into nothing! Now faster!",
 		"type": "TrashCompactor",
 		"sprite": "trashcan fast",
 		"upgrades": "AutoFastTrashCompactor",
@@ -375,6 +426,7 @@
 	},
 	{
 		"_template": "AutoFastTrashCompactor",
+		"description": "Turn two of anything into nothing! Now hands-free and faster!",
 		"type": "TrashCompactor",
 		"sprite": "trashcan motor fast",
 		"automatic": true,

--- a/data/save_20240603114137.json
+++ b/data/save_20240603114137.json
@@ -337,13 +337,13 @@
         "type": "EmptyGriddle"
       },
       {
-        "traversable": true,
+        "traversable": false,
         "quarter_turns": 0,
         "_template": "",
-        "sprite": "",
+        "sprite": "player green",
         "x": 6,
         "y": 3,
-        "type": "EmptyGriddle"
+        "type": "PlayerGriddle"
       },
       {
         "traversable": true,
@@ -678,13 +678,13 @@
         "type": "EmptyGriddle"
       },
       {
-        "traversable": false,
+        "traversable": true,
         "quarter_turns": 0,
         "_template": "",
-        "sprite": "player green",
+        "sprite": "",
         "x": 5,
         "y": 7,
-        "type": "PlayerGriddle"
+        "type": "EmptyGriddle"
       },
       {
         "traversable": false,


### PR DESCRIPTION
Tags are now used for finding rewards instead of a separate field. Will be used for other lookups as well.

Press ? next to a griddle to see the description.

Resolves #25 
Resolves #27