### PR TITLE
Local work

### DIFF
--- a/Grid.pde
+++ b/Grid.pde
@@ -27,7 +27,7 @@ class Grid
     this.w = w;
     this.h = h;
     
-    edge_width = Math.min(dim.x / w, dim.y / h);
+    edge_width = floor(Math.min(dim.x / w, dim.y / h));
     pos = original_pos.copy().add(dim.copy().sub((new PVector(w,h)).mult(edge_width)).mult(0.5f));
     
     griddles = new ArrayList<Griddle>(); 

--- a/data/Rules.json
+++ b/data/Rules.json
@@ -142,7 +142,7 @@
 		"tags": ["curse","walls"],
 		"dependencies": [ ],
 		"mods": [
-			"add 0.85 to Walls:Internal",
+			"add 0.15 to Walls:Internal",
 		],
 	},
 	

--- a/data/Rules.json
+++ b/data/Rules.json
@@ -136,6 +136,15 @@
 			"add 'Tailings' to Resource:Random",
 		],
 	},
+	{
+		"name": "Wall Things End",
+		"description": "Add more internal walls!",
+		"tags": ["curse","walls"],
+		"dependencies": [ ],
+		"mods": [
+			"add 0.85 to Walls:Internal",
+		],
+	},
 	
 	
 	


### PR DESCRIPTION
Pathfinding check was not done properly, so it was possible for items (or the player) to get locked in when new internal walls were generated. This has now been fixed, so walls will never generate in a spot that would trap another non-wall space.